### PR TITLE
Sync patches from 1.83.0-4.1, 1.83.0-4.2 and 1.83.0-5

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+boost1.83 (1.83.0-4deepin3) unstable; urgency=medium
+
+  * Sync patches from 1.83.0-4.1, 1.83.0-4.2 and 1.83.0-5. Changes includes:
+    - Fix FTBFS with NumPy 2.x. Closes: #1094654.
+    - Another fix for numpy 2.0. Closes: #1099671.
+      - Compare pointers directly instead of using PyArray_EquivTypes
+    - Enable context library on ppc64. Closes: #1071542.
+    - Use static const for next/prior from C++17. Closes: #1093824.
+    - [ebf48a2] Fix build on clang-19. (Closes: #1097629)
+
+ -- Tianyu Chen <sweetyfish@deepin.org>  Wed, 29 Oct 2025 11:02:19 +0800
+
 boost1.83 (1.83.0-4deepin2) unstable; urgency=medium
 
   * feat: add sw64 support.

--- a/debian/control
+++ b/debian/control
@@ -380,7 +380,7 @@ Conflicts: libboost-container1.65-dev, libboost-container1.67-dev, libboost-cont
 
 Package: libboost-context1.83.0
 Homepage: http://www.boost.org/libs/context/
-Architecture: i386 hurd-i386 kfreebsd-i386 amd64 hurd-amd64 kfreebsd-amd64 armel armhf arm64 loong64 mips mipsel mips64el powerpc ppc64el riscv64 s390x sw64
+Architecture: i386 hurd-i386 kfreebsd-i386 amd64 hurd-amd64 kfreebsd-amd64 armel armhf arm64 loong64 mips mipsel mips64el powerpc ppc64 ppc64el riscv64 s390x sw64
 Multi-Arch: same
 Depends: ${misc:Depends}, ${shlibs:Depends}
 Pre-Depends: ${misc:Pre-Depends}

--- a/debian/patches/0013-Support-numpy-2.0.0b1.patch
+++ b/debian/patches/0013-Support-numpy-2.0.0b1.patch
@@ -1,0 +1,27 @@
+From: Alexis DUBURCQ <alexis.duburcq@gmail.com>
+Date: Fri, 15 Mar 2024 14:10:16 +0100
+Subject: Support numpy 2.0.0b1
+
+---
+ libs/python/src/numpy/dtype.cpp | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/libs/python/src/numpy/dtype.cpp b/libs/python/src/numpy/dtype.cpp
+index 88a20a2..da30d19 100644
+--- a/libs/python/src/numpy/dtype.cpp
++++ b/libs/python/src/numpy/dtype.cpp
+@@ -98,7 +98,13 @@ python::detail::new_reference dtype::convert(object const & arg, bool align)
+   return python::detail::new_reference(reinterpret_cast<PyObject*>(obj));
+ }
+ 
+-int dtype::get_itemsize() const { return reinterpret_cast<PyArray_Descr*>(ptr())->elsize;}
++int dtype::get_itemsize() const {
++#if NPY_ABI_VERSION < 0x02000000
++  return reinterpret_cast<PyArray_Descr*>(ptr())->elsize;
++#else
++  return PyDataType_ELSIZE(reinterpret_cast<PyArray_Descr*>(ptr()));
++#endif
++}
+ 
+ bool equivalent(dtype const & a, dtype const & b) {
+     // On Windows x64, the behaviour described on 

--- a/debian/patches/0014-Another-fix-for-numpy-2.0.patch
+++ b/debian/patches/0014-Another-fix-for-numpy-2.0.patch
@@ -1,0 +1,47 @@
+From: "Billy K. Poon" <bkpoon@lbl.gov>
+Date: Mon, 15 Jul 2024 15:48:38 -0700
+Subject: Another fix for numpy 2.0
+
+- Compare pointers directly instead of using PyArray_EquivTypes
+---
+ libs/python/src/numpy/dtype.cpp | 27 +--------------------------
+ 1 file changed, 1 insertion(+), 26 deletions(-)
+
+diff --git a/libs/python/src/numpy/dtype.cpp b/libs/python/src/numpy/dtype.cpp
+index da30d19..1ce8c6e 100644
+--- a/libs/python/src/numpy/dtype.cpp
++++ b/libs/python/src/numpy/dtype.cpp
+@@ -107,32 +107,7 @@ int dtype::get_itemsize() const {
+ }
+ 
+ bool equivalent(dtype const & a, dtype const & b) {
+-    // On Windows x64, the behaviour described on 
+-    // http://docs.scipy.org/doc/numpy/reference/c-api.array.html for
+-    // PyArray_EquivTypes unfortunately does not extend as expected:
+-    // "For example, on 32-bit platforms, NPY_LONG and NPY_INT are equivalent".
+-    // This should also hold for 64-bit platforms (and does on Linux), but not
+-    // on Windows. Implement an alternative:
+-#ifdef _MSC_VER
+-    if (sizeof(long) == sizeof(int) &&
+-        // Manually take care of the type equivalence.
+-        ((a == dtype::get_builtin<long>() || a == dtype::get_builtin<int>()) &&
+-         (b == dtype::get_builtin<long>() || b == dtype::get_builtin<int>()) ||
+-         (a == dtype::get_builtin<unsigned int>() || a == dtype::get_builtin<unsigned long>()) &&
+-         (b == dtype::get_builtin<unsigned int>() || b == dtype::get_builtin<unsigned long>()))) {
+-        return true;
+-    } else {
+-        return PyArray_EquivTypes(
+-            reinterpret_cast<PyArray_Descr*>(a.ptr()),
+-            reinterpret_cast<PyArray_Descr*>(b.ptr())
+-        );
+-    }
+-#else
+-    return PyArray_EquivTypes(
+-        reinterpret_cast<PyArray_Descr*>(a.ptr()),
+-        reinterpret_cast<PyArray_Descr*>(b.ptr())
+-    );
+-#endif
++  return a == b;
+ }
+ 
+ namespace

--- a/debian/patches/0015-Use-static-const-for-next-prior-from-C-17.patch
+++ b/debian/patches/0015-Use-static-const-for-next-prior-from-C-17.patch
@@ -1,0 +1,23 @@
+From: Ed Catmur <ed@catmur.uk>
+Date: Fri, 24 Nov 2023 08:53:05 -0700
+Subject: Use static const for next/prior from C++17
+
+Trying to form next/prior in constant evaluation may be ill-formed; see https://github.com/boostorg/mpl/issues/69
+---
+ libs/mpl/include/boost/mpl/aux_/integral_wrapper.hpp | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/libs/mpl/include/boost/mpl/aux_/integral_wrapper.hpp b/libs/mpl/include/boost/mpl/aux_/integral_wrapper.hpp
+index 8748fbb..5f24b79 100644
+--- a/libs/mpl/include/boost/mpl/aux_/integral_wrapper.hpp
++++ b/libs/mpl/include/boost/mpl/aux_/integral_wrapper.hpp
+@@ -56,7 +56,8 @@ struct AUX_WRAPPER_NAME
+ // have to #ifdef here: some compilers don't like the 'N + 1' form (MSVC),
+ // while some other don't like 'value + 1' (Borland), and some don't like
+ // either
+-#if BOOST_WORKAROUND(__EDG_VERSION__, <= 243)
++#if BOOST_WORKAROUND(__EDG_VERSION__, <= 243) \
++    || __cplusplus >= 201103L
+  private:
+     BOOST_STATIC_CONSTANT(AUX_WRAPPER_VALUE_TYPE, next_value = BOOST_MPL_AUX_STATIC_CAST(AUX_WRAPPER_VALUE_TYPE, (N + 1)));
+     BOOST_STATIC_CONSTANT(AUX_WRAPPER_VALUE_TYPE, prior_value = BOOST_MPL_AUX_STATIC_CAST(AUX_WRAPPER_VALUE_TYPE, (N - 1)));

--- a/debian/patches/0016-Fix-build-on-clang-19-which-checks-more-things-in-un.patch
+++ b/debian/patches/0016-Fix-build-on-clang-19-which-checks-more-things-in-un.patch
@@ -1,0 +1,23 @@
+From: Arvid Norlander <arvid-norlander@users.noreply.github.com>
+Date: Fri, 8 Nov 2024 16:48:43 +0100
+Subject: Fix build on clang-19 (which checks more things in uninstantiated
+ templates)
+
+Fixes issue #402
+---
+ libs/thread/include/boost/thread/future.hpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libs/thread/include/boost/thread/future.hpp b/libs/thread/include/boost/thread/future.hpp
+index bbf0ffc..989baba 100644
+--- a/libs/thread/include/boost/thread/future.hpp
++++ b/libs/thread/include/boost/thread/future.hpp
+@@ -4669,7 +4669,7 @@ namespace detail
+       }
+       run_it& operator=(BOOST_THREAD_RV_REF(run_it) x) BOOST_NOEXCEPT {
+         if (this != &x) {
+-          that_=x.that;
++          that_=x.that_;
+           x.that_.reset();
+         }
+         return *this;

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -9,4 +9,8 @@ fix_extension.patch
 60.patch
 70-boost-causing-ftbfs-signal2-part1.patch
 71-boost-causing-ftbfs-signal2-part2.patch
+0013-Support-numpy-2.0.0b1.patch
+0014-Another-fix-for-numpy-2.0.patch
+0015-Use-static-const-for-next-prior-from-C-17.patch
+0016-Fix-build-on-clang-19-which-checks-more-things-in-un.patch
 0001-feat-add-sw64-support.patch


### PR DESCRIPTION
Changes includes:

- Fix FTBFS with NumPy 2.x. Closes: #1094654.
- Another fix for numpy 2.0. Closes: #1099671.
  - Compare pointers directly instead of using PyArray_EquivTypes
- Enable context library on ppc64. Closes: #1071542.
- Use static const for next/prior from C++17. Closes: #1093824.
- [ebf48a2] Fix build on clang-19. (Closes: #1097629)